### PR TITLE
feat: Department 도메인 구현

### DIFF
--- a/src/main/java/mango/rentalsystem/domain/department/api/DepartmentController.java
+++ b/src/main/java/mango/rentalsystem/domain/department/api/DepartmentController.java
@@ -3,7 +3,7 @@ package mango.rentalsystem.domain.department.api;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,7 +12,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mango.rentalsystem.domain.auth.domain.LoginUser;
 import mango.rentalsystem.domain.department.application.DepartmentService;
-import mango.rentalsystem.domain.department.dto.request.DepartmentUpdateRequest;
+import mango.rentalsystem.domain.department.dto.request.DepartmentRentalTimeUpdateRequest;
+import mango.rentalsystem.domain.department.dto.request.DepartmentInfoUpdateRequest;
 import mango.rentalsystem.domain.department.dto.response.DepartmentResponse;
 
 @RestController
@@ -25,13 +26,22 @@ public class DepartmentController {
 	@GetMapping
 	@PreAuthorize("hasRole('MEMBER')")
 	public ResponseEntity<DepartmentResponse> getDepartment(@LoginUser String studentId) {
+		return ResponseEntity.ok(departmentService.getDepartment(studentId));
+	}
+
+	@PutMapping
+	@PreAuthorize("hasRole('ADMIN')")
+	public ResponseEntity<Void> updateDepartmentInfo(@LoginUser String studentId,
+		@Valid @RequestBody DepartmentInfoUpdateRequest request) {
+		departmentService.updateDepartmentInfo(studentId, request);
 		return ResponseEntity.ok().build();
 	}
 
-	@PatchMapping
+	@PutMapping("/rentaltime")
 	@PreAuthorize("hasRole('ADMIN')")
-	public ResponseEntity<Void> updateDepartment(@LoginUser String studentId,
-		@Valid @RequestBody DepartmentUpdateRequest request) {
+	public ResponseEntity<Void> updateDepartmentRentalTime(@LoginUser String studentId,
+		@Valid @RequestBody DepartmentRentalTimeUpdateRequest request) {
+		departmentService.updateDepartmentRentalTime(studentId, request);
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/mango/rentalsystem/domain/department/api/DepartmentController.java
+++ b/src/main/java/mango/rentalsystem/domain/department/api/DepartmentController.java
@@ -1,7 +1,37 @@
 package mango.rentalsystem.domain.department.api;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import mango.rentalsystem.domain.auth.domain.LoginUser;
+import mango.rentalsystem.domain.department.application.DepartmentService;
+import mango.rentalsystem.domain.department.dto.request.DepartmentUpdateRequest;
+import mango.rentalsystem.domain.department.dto.response.DepartmentResponse;
+
 @RestController
+@RequestMapping("/department")
+@RequiredArgsConstructor
 public class DepartmentController {
+
+	private final DepartmentService departmentService;
+
+	@GetMapping
+	@PreAuthorize("hasRole('MEMBER')")
+	public ResponseEntity<DepartmentResponse> getDepartment(@LoginUser String studentId) {
+		return ResponseEntity.ok().build();
+	}
+
+	@PatchMapping
+	@PreAuthorize("hasRole('ADMIN')")
+	public ResponseEntity<Void> updateDepartment(@LoginUser String studentId,
+		@Valid @RequestBody DepartmentUpdateRequest request) {
+		return ResponseEntity.ok().build();
+	}
 }

--- a/src/main/java/mango/rentalsystem/domain/department/application/DepartmentService.java
+++ b/src/main/java/mango/rentalsystem/domain/department/application/DepartmentService.java
@@ -1,7 +1,42 @@
 package mango.rentalsystem.domain.department.application;
 
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import mango.rentalsystem.domain.department.domain.Department;
+import mango.rentalsystem.domain.department.dto.request.DepartmentRentalTimeUpdateRequest;
+import mango.rentalsystem.domain.department.dto.request.DepartmentInfoUpdateRequest;
+import mango.rentalsystem.domain.department.dto.response.DepartmentResponse;
+import mango.rentalsystem.domain.member.dao.MemberRepository;
+import mango.rentalsystem.domain.member.domain.Member;
 
 @Service
+@Transactional
+@RequiredArgsConstructor
 public class DepartmentService {
+
+	private final MemberRepository memberRepository;
+
+	public DepartmentResponse getDepartment(String studentId) {
+		Member member = memberRepository.findByStudentId(studentId)
+			.orElseThrow(() -> new UsernameNotFoundException("학번이 존재하지 않습니다."));
+		Department department = member.getDepartment();
+		return DepartmentResponse.from(department);
+	}
+
+	public void updateDepartmentInfo(String studentId, DepartmentInfoUpdateRequest request) {
+		Member member = memberRepository.findByStudentId(studentId)
+			.orElseThrow(() -> new UsernameNotFoundException("학번이 존재하지 않습니다."));
+		Department department = member.getDepartment();
+		department.updateDepartmentInfo(request.name(), request.rentalPlace(), request.notice());
+	}
+
+	public void updateDepartmentRentalTime(String studentId, DepartmentRentalTimeUpdateRequest request) {
+		Member member = memberRepository.findByStudentId(studentId)
+			.orElseThrow(() -> new UsernameNotFoundException("학번이 존재하지 않습니다."));
+		Department department = member.getDepartment();
+		department.updateWeeklyRentalTime(request.weeklyRentalTime());
+	}
 }

--- a/src/main/java/mango/rentalsystem/domain/department/dao/DepartmentRepository.java
+++ b/src/main/java/mango/rentalsystem/domain/department/dao/DepartmentRepository.java
@@ -1,7 +1,8 @@
 package mango.rentalsystem.domain.department.dao;
 
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-@Repository
-public class DepartmentRepository {
+import mango.rentalsystem.domain.department.domain.Department;
+
+public interface DepartmentRepository extends JpaRepository<Department, Long> {
 }

--- a/src/main/java/mango/rentalsystem/domain/department/domain/DailyRentalTime.java
+++ b/src/main/java/mango/rentalsystem/domain/department/domain/DailyRentalTime.java
@@ -1,6 +1,5 @@
 package mango.rentalsystem.domain.department.domain;
 
-import java.time.Duration;
 import java.time.LocalTime;
 
 import jakarta.persistence.Embeddable;
@@ -25,7 +24,8 @@ public class DailyRentalTime {
 	private LocalTime rentalDeadLineTime;
 
 	@Builder(access = AccessLevel.PRIVATE)
-	private DailyRentalTime(LocalTime rentalStartTime, LocalTime rentalEndTime, int rentalDeadLineDate, LocalTime rentalDeadLineTime) {
+	private DailyRentalTime(LocalTime rentalStartTime, LocalTime rentalEndTime, int rentalDeadLineDate,
+		LocalTime rentalDeadLineTime) {
 		this.rentalStartTime = rentalStartTime;
 		this.rentalEndTime = rentalEndTime;
 		this.rentalDeadLineDate = rentalDeadLineDate;

--- a/src/main/java/mango/rentalsystem/domain/department/domain/DailyRentalTime.java
+++ b/src/main/java/mango/rentalsystem/domain/department/domain/DailyRentalTime.java
@@ -5,6 +5,7 @@ import java.time.LocalTime;
 
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,11 +20,25 @@ public class DailyRentalTime {
 
 	private LocalTime rentalEndTime;
 
-	private Duration rentalDeadLine;
+	private int rentalDeadLineDate; // today.plusDays(rentalDeadLineDate) 처럼 이용.
 
-	public DailyRentalTime(LocalTime rentalStartTime, LocalTime rentalEndTime, Duration rentalDeadLine) {
+	private LocalTime rentalDeadLineTime;
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private DailyRentalTime(LocalTime rentalStartTime, LocalTime rentalEndTime, int rentalDeadLineDate, LocalTime rentalDeadLineTime) {
 		this.rentalStartTime = rentalStartTime;
 		this.rentalEndTime = rentalEndTime;
-		this.rentalDeadLine = rentalDeadLine;
+		this.rentalDeadLineDate = rentalDeadLineDate;
+		this.rentalDeadLineTime = rentalDeadLineTime;
+	}
+
+	public static DailyRentalTime createDailyRentalTime(LocalTime rentalStartTime, LocalTime rentalEndTime,
+		int rentalDeadLineDate, LocalTime rentalDeadLineTime) {
+		return DailyRentalTime.builder()
+			.rentalStartTime(rentalStartTime)
+			.rentalEndTime(rentalEndTime)
+			.rentalDeadLineDate(rentalDeadLineDate)
+			.rentalDeadLineTime(rentalDeadLineTime)
+			.build();
 	}
 }

--- a/src/main/java/mango/rentalsystem/domain/department/domain/Department.java
+++ b/src/main/java/mango/rentalsystem/domain/department/domain/Department.java
@@ -2,7 +2,6 @@ package mango.rentalsystem.domain.department.domain;
 
 import java.time.DayOfWeek;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import jakarta.persistence.CollectionTable;
@@ -15,13 +14,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapKeyColumn;
 import jakarta.persistence.MapKeyEnumerated;
-import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import mango.rentalsystem.domain.category.domain.Category;
-import mango.rentalsystem.domain.member.domain.Member;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Department {
 
 	@Id
@@ -31,13 +31,36 @@ public class Department {
 
 	private String name;
 
+	private String rentalPlace;
+
+	private String notice;
+
 	@ElementCollection
 	@CollectionTable(name = "weekly_rental_time", joinColumns = @JoinColumn(name = "department_id"))
 	@MapKeyColumn(name = "day_of_week")
 	@MapKeyEnumerated(EnumType.STRING)
 	private Map<DayOfWeek, DailyRentalTime> weeklyRentalTime = new HashMap<>();
 
-	private String place;
+	@Builder(access = AccessLevel.PRIVATE)
+	private Department(String name, String rentalPlace, Map<DayOfWeek, DailyRentalTime> weeklyRentalTime,
+		String notice) {
+		this.name = name;
+		this.rentalPlace = rentalPlace;
+		this.weeklyRentalTime = weeklyRentalTime;
+		this.notice = notice;
+	}
 
-	private String notice;
+	public static Department createDepartment(String name, Map<DayOfWeek, DailyRentalTime> weeklyRentalTime) {
+		return Department.builder().name(name).weeklyRentalTime(weeklyRentalTime).build();
+	}
+
+	public void updateDepartmentInfo(String name, String rentalPlace, String notice) {
+		this.name = name;
+		this.rentalPlace = rentalPlace;
+		this.notice = notice;
+	}
+
+	public void updateWeeklyRentalTime(Map<DayOfWeek, DailyRentalTime> weeklyRentalTime) {
+		this.weeklyRentalTime = weeklyRentalTime;
+	}
 }

--- a/src/main/java/mango/rentalsystem/domain/department/domain/Department.java
+++ b/src/main/java/mango/rentalsystem/domain/department/domain/Department.java
@@ -1,6 +1,7 @@
 package mango.rentalsystem.domain.department.domain;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -62,5 +63,9 @@ public class Department {
 
 	public void updateWeeklyRentalTime(Map<DayOfWeek, DailyRentalTime> weeklyRentalTime) {
 		this.weeklyRentalTime = weeklyRentalTime;
+	}
+
+	public DailyRentalTime getTodayRentalTime() {
+		return this.weeklyRentalTime.get(LocalDate.now().getDayOfWeek());
 	}
 }

--- a/src/main/java/mango/rentalsystem/domain/department/domain/Department.java
+++ b/src/main/java/mango/rentalsystem/domain/department/domain/Department.java
@@ -40,12 +40,4 @@ public class Department {
 	private String place;
 
 	private String notice;
-
-
-	//member test용으로 제외
-	/*@OneToMany(mappedBy = "department")
-	private List<Member> members;*/
-
-	@OneToMany(mappedBy = "department")
-	private List<Category> categories;
 }

--- a/src/main/java/mango/rentalsystem/domain/department/dto/request/DepartmentInfoUpdateRequest.java
+++ b/src/main/java/mango/rentalsystem/domain/department/dto/request/DepartmentInfoUpdateRequest.java
@@ -1,0 +1,12 @@
+package mango.rentalsystem.domain.department.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record DepartmentInfoUpdateRequest(
+	@NotNull(message = "학과명을 입력해주세요.")
+	String name,
+	@NotNull(message = "대여 장소를 입력해주세요.")
+	String rentalPlace,
+	@NotNull(message = "공지사항을 입력해주세요.")
+	String notice) {
+}

--- a/src/main/java/mango/rentalsystem/domain/department/dto/request/DepartmentRentalTimeUpdateRequest.java
+++ b/src/main/java/mango/rentalsystem/domain/department/dto/request/DepartmentRentalTimeUpdateRequest.java
@@ -1,0 +1,12 @@
+package mango.rentalsystem.domain.department.dto.request;
+
+import java.time.DayOfWeek;
+import java.util.Map;
+
+import jakarta.validation.constraints.NotNull;
+import mango.rentalsystem.domain.department.domain.DailyRentalTime;
+
+public record DepartmentRentalTimeUpdateRequest(
+	@NotNull(message = "대여업무 시간 정보를 입력해주세요.")
+	Map<DayOfWeek, DailyRentalTime> weeklyRentalTime) {
+}

--- a/src/main/java/mango/rentalsystem/domain/department/dto/request/DepartmentUpdateRequest.java
+++ b/src/main/java/mango/rentalsystem/domain/department/dto/request/DepartmentUpdateRequest.java
@@ -1,4 +1,0 @@
-package mango.rentalsystem.domain.department.dto.request;
-
-public record DepartmentUpdateRequest() {
-}

--- a/src/main/java/mango/rentalsystem/domain/department/dto/request/DepartmentUpdateRequest.java
+++ b/src/main/java/mango/rentalsystem/domain/department/dto/request/DepartmentUpdateRequest.java
@@ -1,0 +1,4 @@
+package mango.rentalsystem.domain.department.dto.request;
+
+public record DepartmentUpdateRequest() {
+}

--- a/src/main/java/mango/rentalsystem/domain/department/dto/response/DepartmentResponse.java
+++ b/src/main/java/mango/rentalsystem/domain/department/dto/response/DepartmentResponse.java
@@ -1,0 +1,4 @@
+package mango.rentalsystem.domain.department.dto.response;
+
+public record DepartmentResponse() {
+}

--- a/src/main/java/mango/rentalsystem/domain/department/dto/response/DepartmentResponse.java
+++ b/src/main/java/mango/rentalsystem/domain/department/dto/response/DepartmentResponse.java
@@ -1,4 +1,23 @@
 package mango.rentalsystem.domain.department.dto.response;
 
-public record DepartmentResponse() {
+import java.time.DayOfWeek;
+import java.util.Map;
+
+import mango.rentalsystem.domain.department.domain.DailyRentalTime;
+import mango.rentalsystem.domain.department.domain.Department;
+
+public record DepartmentResponse(
+	String name,
+	String rentalPlace,
+	String notice,
+	Map<DayOfWeek, DailyRentalTime> weeklyRentalTime) {
+
+	public static DepartmentResponse from(Department department) {
+		return new DepartmentResponse(
+			department.getName(),
+			department.getRentalPlace(),
+			department.getNotice(),
+			department.getWeeklyRentalTime()
+		);
+	}
 }

--- a/src/main/java/mango/rentalsystem/domain/rental/api/RentalController.java
+++ b/src/main/java/mango/rentalsystem/domain/rental/api/RentalController.java
@@ -1,7 +1,44 @@
 package mango.rentalsystem.domain.rental.api;
 
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import mango.rentalsystem.domain.rental.application.RentalService;
+import mango.rentalsystem.domain.rental.domain.Rental;
+import mango.rentalsystem.domain.rental.dto.request.RentalRequest;
+
 @RestController
+@RequestMapping("/rental")
+@RequiredArgsConstructor
 public class RentalController {
+
+	private final RentalService rentalService;
+
+	@GetMapping
+	@PreAuthorize("hasRole('MEMBER')")
+	public ResponseEntity<List<Rental>> getRentals() {
+		return null;
+	}
+
+	@PostMapping
+	@PreAuthorize("hasRole('MEMBER')")
+	public ResponseEntity<Void> postRental(@Valid @RequestBody RentalRequest rentalRequest) {
+		return null;
+	}
+
+	@PatchMapping
+	@PreAuthorize("hasRole('MEMBER')")
+	public ResponseEntity<Void> patchRentalStatus(@Valid @RequestBody RentalRequest rentalRequest) {
+		return null;
+	}
 }

--- a/src/main/java/mango/rentalsystem/domain/rental/application/RentalService.java
+++ b/src/main/java/mango/rentalsystem/domain/rental/application/RentalService.java
@@ -1,7 +1,12 @@
 package mango.rentalsystem.domain.rental.application;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
+@Transactional
+@RequiredArgsConstructor
 public class RentalService {
 }

--- a/src/main/java/mango/rentalsystem/domain/rental/dao/RentalRepository.java
+++ b/src/main/java/mango/rentalsystem/domain/rental/dao/RentalRepository.java
@@ -1,7 +1,8 @@
 package mango.rentalsystem.domain.rental.dao;
 
-import org.springframework.stereotype.Repository;
+import org.springframework.data.repository.CrudRepository;
 
-@Repository
-public class RentalRepository {
+import mango.rentalsystem.domain.rental.domain.Rental;
+
+public interface RentalRepository extends CrudRepository<Rental, Long> {
 }

--- a/src/main/java/mango/rentalsystem/domain/rental/dto/request/RentalRequest.java
+++ b/src/main/java/mango/rentalsystem/domain/rental/dto/request/RentalRequest.java
@@ -1,0 +1,4 @@
+package mango.rentalsystem.domain.rental.dto.request;
+
+public record RentalRequest() {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #23 

## 📝작업 내용

> Department 엔티티에 builder 패턴 적용 후 정적 팩토리 메서드 구현. (create 메서드 자체는 테스트케이스가 아니면 현재는 사용처가 없음. 만일 클라이언트에서 admin 페이지 구현 후 department 초기 생성하는 부분이 생긴다면 사용하겠지만, 웬만하면 초기값을 줄 듯?))


## 💬리뷰 요구사항(선택)

> Rental 도메인에서의 코드 가독성을 위해 Department 엔티티에 `getTodayRentalTime()` 이라는 편의 메서드를 추가했습니다. 혹시 다른 도메인에서 이러한 편의 메서드가 필요하다면 말해주세요.